### PR TITLE
Update booking add-ons logic

### DIFF
--- a/booking.js
+++ b/booking.js
@@ -15,20 +15,17 @@ document.addEventListener('DOMContentLoaded', function() {
   function mapServiceKey(base, addons) {
     const set = new Set(addons);
     const comboBases = ['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry'];
-    const extrasOrder = ['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry'];
 
     if (comboBases.includes(base)) {
-      const parts = [base];
-      extrasOrder.forEach(extra => {
-        if (extra !== base && set.has(extra)) parts.push(extra);
-      });
-      return parts.join('_');
-    } else if (base === 'mens_cut') {
-      if (set.has('beard_trim')) return 'mens_cut_beard';
-      return 'mens_cut';
-    } else {
-      return base;
+      const extras = comboBases.filter(extra => extra !== base && set.has(extra));
+      return [base, ...extras].join('_');
     }
+
+    if (base === 'mens_cut') {
+      return set.has('beard_trim') ? 'mens_cut_beard' : 'mens_cut';
+    }
+
+    return base;
   }
 
   function updateServiceKey() {

--- a/booking.js
+++ b/booking.js
@@ -14,27 +14,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function mapServiceKey(base, addons) {
     const set = new Set(addons);
-    if (base === 'color_regular' || base === 'color_inoa') {
-      const prefix = base;
-      if (set.has('ampule') && set.has('womens_cut') && set.has('blow_dry')) {
-        return `${prefix}_ampule_womens_cut_blow_dry`;
-      }
-      if (set.has('ampule') && set.has('womens_cut')) {
-        return `${prefix}_ampule_womens_cut`;
-      }
-      if (set.has('ampule') && set.has('blow_dry')) {
-        return `${prefix}_ampule_blow_dry`;
-      }
-      if (set.has('womens_cut') && set.has('blow_dry')) {
-        return `${prefix}_womens_cut_blow_dry`;
-      }
-      if (set.has('ampule')) return `${prefix}_ampule`;
-      if (set.has('womens_cut')) return `${prefix}_womens_cut`;
-      if (set.has('blow_dry')) return `${prefix}_blow_dry`;
-      return prefix;
-    } else if (base === 'ampule') {
-      if (set.has('blow_dry')) return 'ampule_blow_dry';
-      return 'ampule';
+    const comboBases = ['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry'];
+    const extrasOrder = ['ampule', 'womens_cut', 'blow_dry'];
+
+    if (comboBases.includes(base)) {
+      const parts = [base];
+      extrasOrder.forEach(extra => {
+        if (extra !== base && set.has(extra)) parts.push(extra);
+      });
+      return parts.join('_');
+    } else if (base === 'mens_cut') {
+      if (set.has('beard_trim')) return 'mens_cut_beard';
+      return 'mens_cut';
     } else {
       return base;
     }
@@ -98,15 +89,38 @@ document.addEventListener('DOMContentLoaded', function() {
 
         removeValidationError(dateInput);
         loadAvailableTimes(dateInput.value);
-        goToStep(2); // To Time selection (0-indexed)
     } else {
         timeSelect.innerHTML = '<option value="">נא לבחור תאריך</option>';
     }
   });
 
   baseServiceSelect.addEventListener('change', function() {
-    if (baseServiceSelect.value === 'color_regular' || baseServiceSelect.value === 'color_inoa' || baseServiceSelect.value === 'ampule') {
+    const baseVal = baseServiceSelect.value;
+    const beardDiv = document.getElementById('addonBeardTrim')?.parentElement;
+    const ampuleDiv = document.getElementById('addonAmpule')?.parentElement;
+    const womensDiv = document.getElementById('addonWomensCut')?.parentElement;
+    const blowDiv = document.getElementById('addonBlowDry')?.parentElement;
+
+    if (['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry', 'mens_cut'].includes(baseVal)) {
       addonsContainer.style.display = 'block';
+      if (baseVal === 'mens_cut') {
+        beardDiv.style.display = 'block';
+        ampuleDiv.style.display = 'none';
+        womensDiv.style.display = 'none';
+        blowDiv.style.display = 'none';
+        document.getElementById('addonAmpule').checked = false;
+        document.getElementById('addonWomensCut').checked = false;
+        document.getElementById('addonBlowDry').checked = false;
+      } else {
+        beardDiv.style.display = 'none';
+        document.getElementById('addonBeardTrim').checked = false;
+        ampuleDiv.style.display = baseVal === 'ampule' ? 'none' : 'block';
+        womensDiv.style.display = baseVal === 'womens_cut' ? 'none' : 'block';
+        blowDiv.style.display = baseVal === 'blow_dry' ? 'none' : 'block';
+        if (baseVal === 'ampule') document.getElementById('addonAmpule').checked = false;
+        if (baseVal === 'womens_cut') document.getElementById('addonWomensCut').checked = false;
+        if (baseVal === 'blow_dry') document.getElementById('addonBlowDry').checked = false;
+      }
     } else {
       addonsContainer.style.display = 'none';
       addonCheckboxes.forEach(c => c.checked = false);
@@ -146,24 +160,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
       if (dateInput.value && /^\d{4}-\d{2}-\d{2}$/.test(dateInput.value)) {
           loadAvailableTimes(dateInput.value);
-          goToStep(2);
-      } else {
-          goToStep(1); // To date selection
-          // Auto-opening datepicker will be handled by goToStep if current step becomes 1
       }
     } else {
         submitBtn.textContent = 'קבעו תור';
         submitBtn.classList.remove('btn-success');
         submitBtn.classList.add('btn-primary');
-        goToStep(0);
     }
   });
 
   timeSelect.addEventListener('change', function() {
     removeValidationError(timeSelect);
-    if (timeSelect.value) {
-      goToStep(3); // To First Name (0-indexed)
-    }
   });
 
   async function loadAvailableTimes(dateStr) {
@@ -332,7 +338,7 @@ document.addEventListener('DOMContentLoaded', function() {
               serviceName: hebrewServiceName
             };
             localStorage.setItem('appointmentDetails', JSON.stringify(appointmentDetails));
-            window.location.href = 'confirmation/';
+            window.location.href = '../confirmation/';
           }
         } catch (err) {
           console.error("[bookingForm submit] Booking error:", err);
@@ -523,8 +529,17 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   document.getElementById('prevBtn-2')?.addEventListener('click', () => goToStep(0));
+  document.getElementById('nextBtn-1')?.addEventListener('click', () => {
+    if (validateSingleStepInputs(steps[0])) goToStep(1);
+  });
   document.getElementById('prevBtn-3')?.addEventListener('click', () => goToStep(1));
+  document.getElementById('nextBtn-2')?.addEventListener('click', () => {
+    if (validateSingleStepInputs(steps[1])) goToStep(2);
+  });
   document.getElementById('prevBtn-4')?.addEventListener('click', () => goToStep(2));
+  document.getElementById('nextBtn-3')?.addEventListener('click', () => {
+    if (validateSingleStepInputs(steps[2])) goToStep(3);
+  });
 
   document.getElementById('nextBtn-4')?.addEventListener('click', () => {
     if(validateSingleStepInputs(steps[3])) goToStep(4);

--- a/booking.js
+++ b/booking.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function mapServiceKey(base, addons) {
     const set = new Set(addons);
     const comboBases = ['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry'];
-    const extrasOrder = ['ampule', 'womens_cut', 'blow_dry'];
+    const extrasOrder = ['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry'];
 
     if (comboBases.includes(base)) {
       const parts = [base];
@@ -100,26 +100,36 @@ document.addEventListener('DOMContentLoaded', function() {
     const ampuleDiv = document.getElementById('addonAmpule')?.parentElement;
     const womensDiv = document.getElementById('addonWomensCut')?.parentElement;
     const blowDiv = document.getElementById('addonBlowDry')?.parentElement;
+    const colorRegDiv = document.getElementById('addonColorRegular')?.parentElement;
+    const colorInoaDiv = document.getElementById('addonColorInoa')?.parentElement;
 
     if (['color_regular', 'color_inoa', 'ampule', 'womens_cut', 'blow_dry', 'mens_cut'].includes(baseVal)) {
       addonsContainer.style.display = 'block';
       if (baseVal === 'mens_cut') {
         beardDiv.style.display = 'block';
-        ampuleDiv.style.display = 'none';
-        womensDiv.style.display = 'none';
-        blowDiv.style.display = 'none';
-        document.getElementById('addonAmpule').checked = false;
-        document.getElementById('addonWomensCut').checked = false;
-        document.getElementById('addonBlowDry').checked = false;
+        [ampuleDiv, womensDiv, blowDiv, colorRegDiv, colorInoaDiv].forEach(div => { if (div) div.style.display = 'none'; });
+        ['addonAmpule','addonWomensCut','addonBlowDry','addonColorRegular','addonColorInoa'].forEach(id => {
+          const cb = document.getElementById(id); if (cb) cb.checked = false; });
       } else {
         beardDiv.style.display = 'none';
         document.getElementById('addonBeardTrim').checked = false;
-        ampuleDiv.style.display = baseVal === 'ampule' ? 'none' : 'block';
-        womensDiv.style.display = baseVal === 'womens_cut' ? 'none' : 'block';
-        blowDiv.style.display = baseVal === 'blow_dry' ? 'none' : 'block';
-        if (baseVal === 'ampule') document.getElementById('addonAmpule').checked = false;
-        if (baseVal === 'womens_cut') document.getElementById('addonWomensCut').checked = false;
-        if (baseVal === 'blow_dry') document.getElementById('addonBlowDry').checked = false;
+        const mapping = {
+          color_regular: 'addonColorRegular',
+          color_inoa: 'addonColorInoa',
+          ampule: 'addonAmpule',
+          womens_cut: 'addonWomensCut',
+          blow_dry: 'addonBlowDry'
+        };
+        [colorRegDiv, colorInoaDiv, ampuleDiv, womensDiv, blowDiv].forEach((div, idx) => {
+          const key = ['color_regular','color_inoa','ampule','womens_cut','blow_dry'][idx];
+          if (!div) return;
+          if (key === baseVal) {
+            div.style.display = 'none';
+            const cb = document.getElementById(mapping[key]); if (cb) cb.checked = false;
+          } else {
+            div.style.display = 'block';
+          }
+        });
       }
     } else {
       addonsContainer.style.display = 'none';
@@ -338,7 +348,7 @@ document.addEventListener('DOMContentLoaded', function() {
               serviceName: hebrewServiceName
             };
             localStorage.setItem('appointmentDetails', JSON.stringify(appointmentDetails));
-            window.location.href = '../confirmation/';
+            window.location.href = '../confirmation/index.html';
           }
         } catch (err) {
           console.error("[bookingForm submit] Booking error:", err);

--- a/booking.js
+++ b/booking.js
@@ -345,7 +345,7 @@ document.addEventListener('DOMContentLoaded', function() {
               serviceName: hebrewServiceName
             };
             localStorage.setItem('appointmentDetails', JSON.stringify(appointmentDetails));
-            window.location.href = '../confirmation/index.html';
+            window.location.href = '../confirmation/';
           }
         } catch (err) {
           console.error("[bookingForm submit] Booking error:", err);

--- a/booking/index.html
+++ b/booking/index.html
@@ -51,16 +51,15 @@
                 <!-- Step 1: Service Selection -->
                 <div class="step active" id="step-1">
                     <div class="form-group">
-                        <label for="baseService" class="text-right">שירות בסיסי:</label>
+                        <label for="baseService" class="text-right">שירות:</label>
                         <select class="form-control" id="baseService" required>
-                            <option value="">בחרו שירות בסיסי</option>
+                            <option value="">בחרו שירות</option>
                             <option value="color_regular">צבע</option>
                             <option value="color_inoa">צבע אינואה</option>
                             <option value="ampule">טיפול אמפולה</option>
                             <option value="womens_cut">תספורת נשים</option>
                             <option value="blow_dry">פן</option>
                             <option value="mens_cut">תספורת גברים</option>
-                            <option value="mens_cut_beard">תספורת גברים עם זקן</option>
                             <option value="gvanim">גוונים</option>
                             <option value="keratin">החלקת קרטין</option>
                         </select>
@@ -80,9 +79,15 @@
                             <input class="form-check-input addon-checkbox" type="checkbox" value="blow_dry" id="addonBlowDry">
                             <label class="form-check-label" for="addonBlowDry">פן</label>
                         </div>
+                        <div class="form-check">
+                            <input class="form-check-input addon-checkbox" type="checkbox" value="beard_trim" id="addonBeardTrim">
+                            <label class="form-check-label" for="addonBeardTrim">תספורת זקן</label>
+                        </div>
                     </div>
                     <select id="haircutType" name="haircutType" style="display:none;" required></select>
-                    <div class="step-buttons"></div>
+                    <div class="step-buttons text-left">
+                        <button type="button" class="btn btn-primary" id="nextBtn-1">הבא</button>
+                    </div>
                 </div>
 
                 <!-- Step 2: Date Selection -->
@@ -97,8 +102,9 @@
                         </div>
                         <div class="invalid-feedback">אנא בחרו תאריך.</div>
                     </div>
-                    <div class="step-buttons text-left">
+                    <div class="step-buttons d-flex justify-content-between">
                         <button type="button" class="btn btn-secondary" id="prevBtn-2">חזור</button>
+                        <button type="button" class="btn btn-primary" id="nextBtn-2">הבא</button>
                     </div>
                 </div>
 
@@ -111,8 +117,9 @@
                         </select>
                         <div class="invalid-feedback">אנא בחרו שעה.</div>
                     </div>
-                    <div class="step-buttons text-left">
+                    <div class="step-buttons d-flex justify-content-between">
                         <button type="button" class="btn btn-secondary" id="prevBtn-3">חזור</button>
+                        <button type="button" class="btn btn-primary" id="nextBtn-3">הבא</button>
                     </div>
                 </div>
 

--- a/booking/index.html
+++ b/booking/index.html
@@ -68,6 +68,14 @@
                     <div class="form-group" id="additionalServices" style="display:none;">
                         <label class="text-right">הוספת שירותים:</label>
                         <div class="form-check">
+                            <input class="form-check-input addon-checkbox" type="checkbox" value="color_regular" id="addonColorRegular">
+                            <label class="form-check-label" for="addonColorRegular">צבע</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input addon-checkbox" type="checkbox" value="color_inoa" id="addonColorInoa">
+                            <label class="form-check-label" for="addonColorInoa">צבע אינואה</label>
+                        </div>
+                        <div class="form-check">
                             <input class="form-check-input addon-checkbox" type="checkbox" value="ampule" id="addonAmpule">
                             <label class="form-check-label" for="addonAmpule">אמפולה</label>
                         </div>


### PR DESCRIPTION
## Summary
- fix booking confirmation redirect link
- allow add-on selections when base service is ampoule, women's cut or blow dry
- compute service key dynamically for these combinations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c464332883219abbcc4875f6dbd9