### PR TITLE
Improve womens cut add-on rules

### DIFF
--- a/booking.js
+++ b/booking.js
@@ -113,6 +113,41 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     haircutTypeSelect.value = key;
   }
+function updateAddonState() {
+  const baseVal = baseServiceSelect.value;
+  const ampuleCb = document.getElementById('addonAmpule');
+  const blowCb = document.getElementById('addonBlowDry');
+  const colorRegCb = document.getElementById('addonColorRegular');
+  const colorInoaCb = document.getElementById('addonColorInoa');
+
+  if (baseVal === 'womens_cut') {
+    if (colorRegCb && addonsContainer.firstChild !== colorRegCb.parentElement) {
+      addonsContainer.prepend(colorRegCb.parentElement);
+    }
+    if (colorInoaCb && addonsContainer.children[1] !== colorInoaCb.parentElement) {
+      addonsContainer.insertBefore(colorInoaCb.parentElement, addonsContainer.children[1] || null);
+    }
+    const colorSelected = (colorRegCb && colorRegCb.checked) || (colorInoaCb && colorInoaCb.checked);
+    [ampuleCb, blowCb].forEach(cb => {
+      if (!cb) return;
+      if (!colorSelected) {
+        cb.checked = false;
+        cb.disabled = true;
+        cb.parentElement.classList.add('disabled-addon');
+      } else {
+        cb.disabled = false;
+        cb.parentElement.classList.remove('disabled-addon');
+      }
+    });
+  } else {
+    [ampuleCb, blowCb].forEach(cb => {
+      if (cb) {
+        cb.disabled = false;
+        cb.parentElement.classList.remove('disabled-addon');
+      }
+    });
+  }
+}
 
   async function loadServices() {
     try {
@@ -217,11 +252,13 @@ document.addEventListener('DOMContentLoaded', function() {
       addonsContainer.style.display = 'none';
     }
     updateServiceKey();
+    updateAddonState();
     haircutTypeSelect.dispatchEvent(new Event('change'));
   });
 
   addonCheckboxes.forEach(cb => cb.addEventListener('change', () => {
     updateServiceKey(cb);
+    updateAddonState();
     haircutTypeSelect.dispatchEvent(new Event('change'));
   }));
 
@@ -686,6 +723,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   loadServices().then(() => {
     updateServiceKey();
+    updateAddonState();
   });
   goToStep(0);
 });

--- a/styles.css
+++ b/styles.css
@@ -299,3 +299,8 @@ h1 {
     line-height: 25px;
     font-size: 1em;
 }
+#additionalServices .disabled-addon label {
+    color: #6c757d;
+    cursor: not-allowed;
+}
+#additionalServices .disabled-addon input{pointer-events:none;}


### PR DESCRIPTION
## Summary
- disable conflicting add-on checkboxes when selecting women's haircut
- highlight add-on disable state with new CSS styles

## Testing
- `node --check booking.js`

------
https://chatgpt.com/codex/tasks/task_e_684d5b3c9d588321b768921061c2958b